### PR TITLE
Fix bug on Signs.java

### DIFF
--- a/src/main/java/it/unive/scsr/Signs.java
+++ b/src/main/java/it/unive/scsr/Signs.java
@@ -185,7 +185,7 @@ public class Signs
                 else
                     return TOP;
             } else if (left == ZERO) {
-                return right;
+                return right.negate();
             } else
                 return TOP;
         } else if (operator instanceof MultiplicationOperator) {


### PR DESCRIPTION
Fix bug on Signs.java: while evaluating the SubtractionOperator, if the left operand is zero, we should return right.negate()


closes #5 